### PR TITLE
Algumas correções no sumário e na folha de rosto

### DIFF
--- a/iftex.cls
+++ b/iftex.cls
@@ -206,7 +206,6 @@
 % --------------------------------------------------- %
 
 \renewcommand{\imprimirfolhaderosto}{
-  \begin{center}
     
     \centering  	
     \vspace*{2.0cm}
@@ -239,7 +238,7 @@
     
     \imprimirlocal\par\imprimirdata
 
-  \end{center}}
+}
 
 % --------------------------------------------------- %
 % CONFIGURAÇÕES DO ASPECTO FINAL DO PDF %

--- a/iftex.cls
+++ b/iftex.cls
@@ -206,7 +206,7 @@
 % --------------------------------------------------- %
 
 \renewcommand{\imprimirfolhaderosto}{
-    
+    \begin{folhaderosto}
     \centering  	
     \vspace*{2.0cm}
 
@@ -237,7 +237,7 @@
     \vfill
     
     \imprimirlocal\par\imprimirdata
-
+    \end{folhaderosto}
 }
 
 % --------------------------------------------------- %

--- a/iftex.cls
+++ b/iftex.cls
@@ -346,7 +346,7 @@
 % 
 \setlength{\cftbeforechapterskip}{0em}
 
-%% O código a seguir configura faz com que os títulos das sections fiquem em caixa alta no sumário
+%% O código a seguir faz com que os títulos das sections fiquem em caixa alta no sumário
 % Agradecimentos ao usuário anônimo em:
 % https://tex.stackexchange.com/questions/399828/how-to-make-the-table-of-contents-section-title-upper-case-without-messing-with/399861
 

--- a/iftex.cls
+++ b/iftex.cls
@@ -323,7 +323,50 @@
 % Subsubsection
 \setlength{\aftersubsubsecskip}{15pt}
 % \setlength{\beforesubsubsecskip}{15pt}
-   
+
+% --------------------------------------------------- %
+% CONFIGURAÇÕES DO SUMÁRIO %
+% --------------------------------------------------- %
+
+\renewcommand{\cftpartfont}{\bfseries\normalsize}
+% 
+\renewcommand{\cftchapterfont}{\bfseries\normalsize}
+\renewcommand{\cftchapterpagefont}{\cftchapterfont}
+% 
+\renewcommand{\cftsectionfont}{\mdseries\normalsize}
+\renewcommand{\cftsectionpagefont}{\cftsectionfont}
+% 
+\renewcommand{\cftsubsectionfont}{\bfseries\normalsize}
+\renewcommand{\cftsubsectionpagefont}{\mdseries\cftsubsectionfont}
+% 
+\renewcommand{\cftsubsubsectionfont}{\mdseries\normalsize}
+\renewcommand{\cftsubsubsectionpagefont}{\cftsubsubsectionfont}
+% 
+\renewcommand{\cftparagraphfont}{\itshape\mdseries\normalsize}
+\renewcommand{\cftparagraphpagefont}{\cftparagraphfont}
+% 
+\setlength{\cftbeforechapterskip}{0em}
+
+%% O código a seguir configura faz com que os títulos das sections fiquem em caixa alta no sumário
+% Agradecimentos ao usuário anônimo em:
+% https://tex.stackexchange.com/questions/399828/how-to-make-the-table-of-contents-section-title-upper-case-without-messing-with/399861
+
+\makeatletter
+\let\oldcontentsline\contentsline
+\def\contentsline#1#2{%
+\expandafter\ifx\csname l@#1\endcsname\l@section
+\expandafter\@firstoftwo
+\else
+\expandafter\@secondoftwo
+\fi
+{%
+\oldcontentsline{#1}{\MakeTextUppercase{#2}}%
+}{%
+\oldcontentsline{#1}{#2}%
+}%
+}
+\makeatother
+
 % --------------------------------------------------- %
 % COMPILA O ÍNDICE %
 % --------------------------------------------------- %


### PR DESCRIPTION
Primeiramente queria agradecer pelo bom trabalho em adaptar as normas do Ifes para o LaTeX.

Nesse PR, conserto o sumário para que os títulos nele correspondam exatamente aos do resto do documento (todos estavam em negrito, os secundários não estavam em caixa alta e os títulos 5 não estavam em itálico)